### PR TITLE
Update to tests based on updated schema with application_name

### DIFF
--- a/app/transfer_service/transfer_service.py
+++ b/app/transfer_service/transfer_service.py
@@ -14,7 +14,7 @@ logging.basicConfig(filename=logfile, level=loglevel)
 def transfer_data(message_data):
     s3_bucket_name = message_data['s3_bucket_name']
     s3_path = message_data['s3_path'] 
-    dest_path = message_data['destination_path']
+    dest_path = os.path.join(message_data['destination_path'], os.path.basename(s3_path))
    
     if not path_exists(s3_bucket_name, s3_path):
         raise TransferException("The path {} does not exists in bucket {}.".format(s3_path, s3_bucket_name))  

--- a/tests/integration/test_mqlistener.py
+++ b/tests/integration/test_mqlistener.py
@@ -84,6 +84,7 @@ def notify_dry_run_data_ready_transfer_message():
         
         msg_json = {
             "dry_run": True,
+            "application_name": "Dataverse",
             "package_id": "12345",
             "s3_path": s3_path,
             "s3_bucket_name": s3_bucket,
@@ -114,6 +115,7 @@ def notify_data_ready_transfer_message():
         
         msg_json = {
             "package_id": "doi-12-3456-transfer-service-test",
+            "application_name": "Dataverse",
             "s3_path": s3_path,
             "s3_bucket_name": s3_bucket,
             "destination_path": destination_path,

--- a/tests/integration/test_transfer.py
+++ b/tests/integration/test_transfer.py
@@ -18,8 +18,7 @@ def test_perform_transfer():
     assert transfer_service.path_exists(s3_bucket, s3_path)
      
     dropbox_path="/home/appuser/local/dropbox"
-     
-    dest_path = os.path.join(dropbox_path, s3_path)
+    dest_path = os.path.join(dropbox_path, os.path.basename(s3_path))
      
     transfer_service.perform_transfer(s3_bucket, s3_path, dest_path)
      

--- a/tests/unit/test_transfer_ready_validation.py
+++ b/tests/unit/test_transfer_ready_validation.py
@@ -5,6 +5,7 @@ import transfer_service.transfer_ready_validation as transfer_ready_validation
 def test_valid_json():
     msg_json = {
         "package_id": "12345",
+        "application_name": "Dataverse",
         "s3_path": "/path/to/data",
         "s3_bucket_name": "dataverse-export-dev",
         "destination_path": "/home/appuser/dropbox",
@@ -20,6 +21,7 @@ def test_valid_json():
 def test_valid_json_extra_admin_params():
     msg_json = {
         "package_id": "12345",
+        "application_name": "Dataverse",
         "s3_path": "/path/to/data",
         "s3_bucket_name": "dataverse-export-dev",
         "destination_path": "/home/appuser/dropbox",
@@ -36,6 +38,7 @@ def test_invalid_json_missing_param():
     with pytest.raises(jsonschema.exceptions.ValidationError):
         msg_json = {
             "package_id": "12345",
+            "application_name": "Dataverse",
             "s3_bucket_name": "dataverse-export-dev",
             "destination_path": "/home/appuser/dropbox",
             "admin_metadata": {"original_queue": "myqueue", "retry_count":0}
@@ -43,15 +46,5 @@ def test_invalid_json_missing_param():
     
         transfer_ready_validation.validate_json_schema(msg_json)
 
-def test_invalid_json_extra_param():
-    with pytest.raises(jsonschema.exceptions.ValidationError):
-        msg_json = {
-            "package_id": "12345",
-            "s3_path": "/path/to/data",
-            "s3_bucket_name": "dataverse-export-dev",
-            "destination_path": "/home/appuser/dropbox",
-            "extra_param": "should fail",
-            "admin_metadata": {"original_queue": "myqueue", "retry_count":0}
-        }
     
         transfer_ready_validation.validate_json_schema(msg_json)


### PR DESCRIPTION
**Tests updated to reflect schema changes*
* * *

# How should this be tested?
Make sure the tests pass:

1. Clone the repo
2. Checkout the branch test_update
3. Copy the env-template.txt to .env
4. Get the credentials from LPE Shared-HDataCommons/3a/dims ActiveMQ dev/qa transfer and process queue for ims-transfer-dev.  Add the credentials to the .env
6. Get the credentials from LPE Shared-HDataCommons/3a/dataverse-export-s3 dev/qa for the dataverse-export-dev access key and secret access key and set them in the .env as appropriate.
7. In the .env, set` SUPPLIED_HASH_MAPPING_FILENAME=manifest-md5.txt`
8. In the .env, set` REQUIRED_UNZIPPED_FILES=bag-info.txt,bagit.txt,metadata/datacite.xml,metadata/oai-ore.jsonld,metadata/pid-mapping.txt`
9. Start up the docker container: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
10. Exec into the container: `docker exec -it hdc3a-transfer-service bash`
11. Run the command `pytest`

